### PR TITLE
Add variable interpolation

### DIFF
--- a/spec/backend/yaml_spec.cr
+++ b/spec/backend/yaml_spec.cr
@@ -47,28 +47,36 @@ describe I18n::Backend::Yaml do
   describe "#localize" do
     time = Time.new(2010, 10, 11, 12, 13, 14)
 
-    it "format number" do
-      backend.localize("pt", 1234).should(eq("1.234"))
+    context "with number format" do
+      it { backend.localize("pt", 123).should(eq("123")) }
+      it { backend.localize("pt", 1234).should(eq("1.234")) }
+      it { backend.localize("pt", 12345).should(eq("12.345")) }
+      it { backend.localize("pt", 123456).should(eq("123.456")) }
+      it { backend.localize("pt", 1234567).should(eq("1.234.567")) }
+      it { backend.localize("pt", 12345678).should(eq("12.345.678")) }
+      it { backend.localize("pt", 123.123).should(eq("123,123")) }
+
+      it { backend.localize("pt", 1234.123, :time).should(eq("1234.123")) }
     end
 
-    it "format number with decimals" do
-      backend.localize("pt", 123.123).should(eq("123,123"))
+    context "with time format" do
+      it "time default format" do
+        backend.localize("pt", time, scope: :time).should(eq(time.to_s("%H:%M:%S")))
+      end
+    end
+
+    context "with date format" do
+      it "date default format" do
+        backend.localize("pt", time, scope: :date).should(eq(time.to_s("%Y-%m-%d")))
+      end
+
+      it "date long format" do
+        backend.localize("en", time, scope: :date, format: "long").should(eq(time.to_s("%A, %d of %B %Y")))
+      end
     end
 
     it "format number to currency" do
       backend.localize("pt", 123.123, scope: :currency).should(eq("123,123€"))
-    end
-
-    it "time default format" do
-      backend.localize("pt", time, scope: :time).should(eq(time.to_s("%H:%M:%S")))
-    end
-
-    it "date default format" do
-      backend.localize("pt", time, scope: :date).should(eq(time.to_s("%Y-%m-%d")))
-    end
-
-    it "date long format" do
-      backend.localize("en", time, scope: :date, format: "long").should(eq(time.to_s("%A, %d of %B %Y")))
     end
   end
 end

--- a/spec/backend/yaml_spec.cr
+++ b/spec/backend/yaml_spec.cr
@@ -32,16 +32,17 @@ describe I18n::Backend::Yaml do
       end
     end
 
+    context "with pluralization" do
+      it { backend.translate("pt", "new_message", count: 1).should(eq("tem uma nova mensagem")) }
+      it { backend.translate("en", "messages.plural", {attr: "a"}, count: 1).should eq("1 a") }
+
+      it { backend.translate("pt", "new_message", count: 2).should(eq("tem 2 novas mensagens")) }
+      it { backend.translate("en", "messages.plural", { :attr => "b" }, count: 2).should eq("2 bs") }
+    end
+
+    it { backend.translate("en", "messages.with_2_arguments", {attr: "a", attr2: "b"}).should eq("a and b") }
     it { backend.translate("pt", "hello").should(eq("olá")) }
-
-    it "pluralization translate 1" do
-      backend.translate("pt", "new_message", count: 1).should(eq("tem uma nova mensagem"))
-    end
-
-    it "pluralization translate 2" do
-      tr = backend.translate("pt", "new_message", count: 2) % {count: 2}
-      tr.should(eq("tem 2 novas mensagens"))
-    end
+    it { backend.translate("pt", "__formats__.date.day_names", iter: 2).should eq("Terça") }
   end
 
   describe "#localize" do

--- a/spec/i18n_spec.cr
+++ b/spec/i18n_spec.cr
@@ -19,21 +19,23 @@ describe I18n do
       end
     end
 
-    it "translate" do
-      I18n.translate("hello").should(eq("olá"))
+    context "with pluralization" do
+      it "pluralization translate 1" do
+        I18n.translate("new_message", count: 1).should(eq("tem uma nova mensagem"))
+      end
+
+      it "pluralization translate 2" do
+        tr = I18n.translate("new_message", count: 2)
+        tr.should(eq("tem 2 novas mensagens"))
+      end
     end
 
-    it "pluralization translate 1" do
-      I18n.translate("new_message", count: 1).should(eq("tem uma nova mensagem"))
-    end
-
-    it "pluralization translate 2" do
-      tr = I18n.translate("new_message", count: 2) % {count: 2}
-      tr.should(eq("tem 2 novas mensagens"))
-    end
+    it { I18n.translate("hello").should(eq("olá")) }
   end
 
   describe ".localize" do
+    time = Time.now
+
     it "format number" do
       I18n.localize(1234).should(eq("1.234"))
     end
@@ -47,18 +49,17 @@ describe I18n do
     end
 
     it "time default format" do
-      time = Time.now
       I18n.localize(time, scope: :time).should(eq(time.to_s("%H:%M:%S")))
     end
 
     it "date default format" do
-      time = Time.now
       I18n.localize(time, scope: :date).should(eq(time.to_s("%Y-%m-%d")))
     end
 
     it "date long format" do
-      time = Time.now
       I18n.localize(time, scope: :date, force_locale: "en", format: "long").should(eq(time.to_s("%A, %d of %B %Y")))
     end
+
+    it { I18n.localize(time, "en", :date, "long").should(eq(time.to_s("%A, %d of %B %Y"))) }
   end
 end

--- a/spec/locales/en.yml
+++ b/spec/locales/en.yml
@@ -1,6 +1,11 @@
 new_message:
     "one"    : "you have a message"
-    "other"  : 'you have %d new messages'
+    "other"  : 'you have %{count} new messages'
+messages:
+    with_2_arguments: "%{attr} and %{attr2}"
+    plural:
+        one: "%{count} %{attr}"
+        other: "%{count} %{attr}s"
 
 __formats__:
     number:
@@ -10,7 +15,7 @@ __formats__:
     currency:
         symbol: '€'
         name: 'euro'
-        format: '%s€'
+        format: '%{amount}€'
 
     date:
         formats:

--- a/spec/locales/pt.yml
+++ b/spec/locales/pt.yml
@@ -10,7 +10,7 @@ __formats__:
     currency:
       symbol: €
       name: euro
-      format: "%s€"
+      format: "%{amount}€"
     date:
       formats:
         default: '%Y-%m-%d'

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,6 +1,6 @@
 require "spec"
 require "../src/i18n"
 
-I18n.load_path += %w(spec/locales spec/locales/subfolder)
+I18n.load_path += %w(spec/**)
 I18n.locale = "pt"
 I18n.init

--- a/src/i18n.cr
+++ b/src/i18n.cr
@@ -15,8 +15,6 @@ module I18n
     {% end %}
   end
 
-  @@inner_config
-
   # Gets I18n configuration object.
   def config
     @@inner_config ||= Config.new
@@ -35,15 +33,13 @@ module I18n
 
   define_delegators(%w(locale backend default_locale available_locales default_separator exception_handler load_path))
 
-  def translate(key : String, force_locale = config.locale, _throw = :throw, count = nil, default = nil, iter = nil) : String
-    backend = config.backend
-    locale = force_locale
-    # handling = _throw
-
+  def translate(key : String, options : Hash | NamedTuple? = nil, force_locale = config.locale, count = nil, default = nil, iter = nil) : String
     raise I18n::ArgumentError.new if key.empty?
 
+    backend = config.backend
+
     begin
-      backend.translate(locale, key, count: count, default: default)
+      backend.translate(force_locale, key, options: options, count: count, default: default)
     rescue e
       e.inspect
     end
@@ -54,39 +50,9 @@ module I18n
     # end
   end
 
-  def translate(key : String, force_locale = config.locale, count = nil, default = nil, iter = nil, &block) : String
-    puts "block"
-    backend = config.backend
-    locale = force_locale
-
-    raise I18n::ArgumentError.new if key.empty?
-
-    result =
-      begin
-        backend.translate(locale, key, count: count, default: default)
-      rescue e
-        e
-      end
-
-    if e.is_a?(MissingTranslation)
-      (yield e).to_s
-    else
-      result.as(String)
-    end
-  end
-
-  def localize(object, force_locale = config.locale, format = nil, scope = :number)
-    result = 
-      begin
-        config.backend.localize(force_locale, object, format: format, scope: scope)
-      rescue e
-        e
-      end
-
-    if result.is_a?(Exception)
-      result.inspect
-    else
-      result
-    end
+  def localize(object, force_locale = config.locale, *args, **options)
+    config.backend.localize(force_locale, object, *args, **options)
+  rescue e
+    e.inspect
   end
 end

--- a/src/i18n/backend/base.cr
+++ b/src/i18n/backend/base.cr
@@ -2,7 +2,7 @@ module I18n
   module Backend
     abstract class Base
       abstract def load(*args)
-      abstract def translate(locale : String, key : String, count = nil, default = nil, iter = nil) : String
+      abstract def translate(locale : String, key : String, opitions : Hash | NamedTuple?, count = nil, default = nil, iter = nil) : String
       abstract def localize(locale : String, object, scope = :number, format = nil) : String
       abstract def available_locales : Array(String)
     end

--- a/src/i18n/backend/yaml.cr
+++ b/src/i18n/backend/yaml.cr
@@ -55,9 +55,9 @@ module I18n
         tr.to_s
       end
 
-      # Localize a number, a date or a datetime, a currency
+      # Localize a number or a currency
       # Use the format if given
-      # scope can be one of :number ( default ), :time, :date, :datetime, :currency
+      # scope can be one of :number ( default ), :currency
       # Following keys are required :
       #
       # __formats__:
@@ -69,7 +69,23 @@ module I18n
       #         symbol: '€'
       #       name: 'euro'
       #       format: '%s€'
+      def localize(locale : String, object : Number, scope = :number, format = nil) : String
+        return object.to_s if scope != :number && scope != :currency
+
+        number = format_number(locale, object)
+        if scope == :currency
+          number = translate(locale, "__formats__.currency.format") % number
+        end
+
+        number
+      end
+
+      # Localize a date or a datetime
+      # Use the format if given
+      # scope can be one of :time ( default ), :date, :datetime
+      # Following keys are required :
       #
+      # __formats__:
       #       date:
       #         formats:
       #         default: "%Y-%m-%d"
@@ -84,36 +100,68 @@ module I18n
       #       time:
       #         formats:
       #             default: "%I:%M:%S %p"
-      def localize(locale : String, object, scope = :number, format = nil) : String
-        base_key = "__formats__."
+      def localize(locale : String, object : Time, scope = :time, format = nil) : String
+        base_key = "__formats__." + scope.to_s + (format ? ".formats." + format.to_s : ".formats.default")
 
-        if object.is_a?(Time) && (scope == :time || scope == :date || scope == :datetime)
-          base_key += scope.to_s + (format ? ".formats." + format.to_s : ".formats.default")
-
-          format = translate(locale, base_key)
-          format = format.to_s.gsub(/%[aAbBpP]/) do |match|
-            case match
-            when "%a" then translate(locale, "__formats__.date.abbr_day_names", iter: object.day_of_week.to_i)
-            when "%A" then translate(locale, "__formats__.date.day_names", iter: object.day_of_week.to_i)
-            when "%b" then translate(locale, "__formats__.date.abbr_month_names", iter: object.month)
-            when "%B" then translate(locale, "__formats__.date.month_names", iter: object.month)
-            when "%p" then translate(locale, "__formats__.time.#{object.hour < 12 ? :am : :pm}").upcase if object.responds_to? :hour
-            when "%P" then translate(locale, "__formats__.time.#{object.hour < 12 ? :am : :pm}").downcase if object.responds_to? :hour
-            end
+        format = translate(locale, base_key)
+        format = format.to_s.gsub(/%[aAbBpP]/) do |match|
+          case match
+          when "%a" then translate(locale, "__formats__.date.abbr_day_names", iter: object.day_of_week.to_i)
+          when "%A" then translate(locale, "__formats__.date.day_names", iter: object.day_of_week.to_i)
+          when "%b" then translate(locale, "__formats__.date.abbr_month_names", iter: object.month)
+          when "%B" then translate(locale, "__formats__.date.month_names", iter: object.month)
+          when "%p" then translate(locale, "__formats__.time.#{object.hour < 12 ? :am : :pm}").upcase if object.responds_to? :hour
+          when "%P" then translate(locale, "__formats__.time.#{object.hour < 12 ? :am : :pm}").downcase if object.responds_to? :hour
           end
-          return object.to_s(format)
-        elsif object.is_a?(Number) && (scope == :number || scope == :currency)
-          number = self.format_number(locale, object)
-
-          if scope == :currency
-            number = translate(locale, "__formats__.currency.format") % number
-          end
-
-          return number
         end
+        object.to_s(format)
+      end
 
+      # Invokes `#to_s` on the `object` ignoring `scope` and `format`
+      def localize(locale : String, object, scope = :number, format = nil) : String
         # Don't know what to do, return the object
         object.to_s
+      end
+
+      # :nodoc:
+      # see https://github.com/whity/crystal-i18n/blob/96defcb7266c7b526ab6f1a5648e3b5b240b6d58/src/i18n/i18n.cr
+      private def format_number(locale : String, object : Number)
+        value = object.to_s
+        # get decimal separator
+        dec_separator = translate(locale, "__formats__.number.decimal_separator")
+        
+        value = value.sub(/\./, dec_separator) if dec_separator
+
+        # ## set precision separator ##
+        # split by decimal separator
+        match = value.match(/(\d+)#{dec_separator}?(\d+)?/)
+
+        return value unless match
+
+        integer = match[1]
+        decimal = match[2]?
+
+        String.build do |io|
+          precision_separator = translate(locale, "__formats__.number.precision_separator")
+          
+          leading_digits = integer.size % 3
+          precision_counter = leading_digits == 0 ? 0 : 3 - leading_digits
+          index = integer.size - 1
+
+          integer.each_char do |char|
+            io << char
+
+            if precision_counter == 2 && index != 0
+              io << precision_separator
+              precision_counter = 0
+            else
+              precision_counter += 1
+            end
+            index -= 1
+          end
+
+          io.print dec_separator, decimal if decimal
+        end
       end
 
       private def load_file(filename)
@@ -124,61 +172,17 @@ module I18n
         end
       end
 
-      # see https://github.com/whity/crystal-i18n/blob/96defcb7266c7b526ab6f1a5648e3b5b240b6d58/src/i18n/i18n.cr
-      def format_number(locale : String, object : Number) : String
-        value = object.to_s
-        # get decimal separator
-        dec_separator = translate(locale, "__formats__.number.decimal_separator")
-        if (dec_separator)
-          value = value.sub(Regex.new("\\."), dec_separator)
-        end
-
-        # ## set precision separator ###
-        # split by decimal separator
-        match = value.match(Regex.new("(\\d+)#{dec_separator}?(\\d+)?", Regex::Options::IGNORE_CASE))
-        if (!match)
-          return value
-        end
-        # match = match as Regex::MatchData
-
-        integer = match[1]
-        decimal = match[2]?
-
-        precision_separator = translate(locale, "__formats__.number.precision_separator")
-        new_value = ""
-        counter = 0
-        index = integer.size - 1
-        while (index >= 0)
-          if (counter >= 3)
-            new_value = precision_separator + new_value
-            counter = 0
-          end
-
-          new_value = integer[index].to_s + new_value
-
-          index -= 1
-          counter += 1
-        end
-
-        value = new_value
-        if (decimal)
-          value += dec_separator + decimal
-        end
-
-        return value
-      end
-
       def self.normalize(data : Hash, path : String = "", final = Hash(String, YAML::Type).new)
         data.keys.each do |k|
           newp = path.size == 0 ? k.to_s : path + "." + k.to_s
           newdata = data[k]
           if newdata.is_a?(Hash)
-            self.normalize(newdata, newp, final)
+            normalize(newdata, newp, final)
           else
             final[newp] = newdata
           end
         end
-        return final
+        final
       end
     end
   end

--- a/src/i18n/exceptions.cr
+++ b/src/i18n/exceptions.cr
@@ -4,7 +4,7 @@ module I18n
   # was caught the handler returns an error message string containing the key/scope.
   # Note that the exception handler is not called when the option :throw was given.
   class ExceptionHandler
-    def call(exception, locale, key, options)
+    def call(exception, locale, key, options, count, default)
       case exception
       when MissingTranslation
         exception.message


### PR DESCRIPTION
- adds variable interpolation to yaml backend
- splits `Yaml#localize` to 3 methods (for `Number`, `Time` and any other)
- optimize `Yaml#format_number` - got near 30% speed up
- updates the README

Proposed solution for attributes interpolation is faster than build in crystal interpolation using `%` and named tuple and allows to pass has with both string and symbol keys (named tuple as well). But on the other hand is slightly slower than 
```crystal
translation_string.gsub(/\%{\w*}/) do |matched|
    options[matched[2..-2]]
end
```

which at the same time provide automatic arity check.