### PR TITLE
Replace travis with github actions; optimize Yaml.embed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,19 @@ jobs:
   test:
     strategy:
       fail-fast: false
+      maxtrix:
+        crystal-version:
+          - latest
+          - '0.29.0'
+          - '0.35.1'
 
     runs-on: ubuntu-latest
 
     steps:
       - name: Install Crystal
         uses: oprypin/install-crystal@v1
+        with:
+          crystal: ${{ matrix.crystal-version }}
 
       - name: Donwload sources
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  pull_request:
+    branches: "*"
+  push:
+    branches: master
+  schedule:
+    - cron: "0 7 * * 1"
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install Crystal
+        uses: oprypin/install-crystal@v1
+
+      - name: Donwload sources
+        uses: actions/checkout@v2
+
+      - name: Check formatting
+        run: crystal tool format --check
+
+      - name: Install dependencies
+        run: shards install
+
+      - name: Run specs
+        run: crystal spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: crystal
-
-script:
-  - crystal spec
-  - crystal tool format --check

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # i18n
 
-[![Build Status](https://travis-ci.org/TechMagister/i18n.cr.svg?branch=master)](https://travis-ci.org/TechMagister/i18n.cr)
+![Build Status](https://github.com/crimson-knight/i18n.cr/actions/workflows/ci.yml/badge.svg)
 
 Internationalization API
 

--- a/spec/backend/yaml_spec.cr
+++ b/spec/backend/yaml_spec.cr
@@ -6,7 +6,17 @@ describe I18n::Backend::Yaml do
   locales.each { |path| backend.load(path) }
 
   describe "%embed" do
-    pending "add" { }
+    it "embeds files from given folder" do
+      with_blank_translations do
+        I18n.backend.translations.clear
+        I18n.backend.translations.should be_empty
+
+        I18n::Backend::Yaml.embed(["spec/locales/subfolder"])
+
+        I18n.backend.translations["en"].has_key?("subfolder_message").should be_true
+        I18n.backend.translations["en"].has_key?("new_message").should be_false
+      end
+    end
   end
 
   describe "#load" do

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -2,7 +2,16 @@ require "spec"
 require "../src/i18n"
 
 I18n.load_path += %w(spec/**)
-I18n.locale = "pt"
 I18n.init
 
 Spec.before_each { I18n.locale = "pt" }
+
+macro with_blank_translations
+  __temp_backend__ = I18n.backend
+  I18n.backend = I18n::Backend::Yaml.new
+  begin
+    {{yield}}
+  ensure
+    I18n.backend = __temp_backend__
+  end
+end

--- a/src/i18n/backend/yaml.cr
+++ b/src/i18n/backend/yaml.cr
@@ -14,10 +14,8 @@ module I18n
       @available_locales = Array(String).new
 
       macro embed(dirs)
-        {% begin %}
-          {% for dir in dirs %}
-            \{{ run("i18n/backend/yaml_embed", {{dir}}) }}
-          {% end %}
+        {% for dir in dirs %}
+          {{ run("./yaml_embed", dir) }}
         {% end %}
       end
 

--- a/src/i18n/backend/yaml_embed.cr
+++ b/src/i18n/backend/yaml_embed.cr
@@ -3,12 +3,12 @@ require "yaml"
 puts ARGV
 dir = ARGV[0]
 
-puts "backend = I18n.backend.as(I18n::Backend::Yaml)"
+puts "__backend__ = I18n.backend.as(I18n::Backend::Yaml)"
 
-files = Dir.glob "#{dir}/*.yml" do |file|
+Dir.glob "#{dir}/*.yml" do |file|
   lang = File.basename file, ".yml"
 
-  # compile time check to ensure yaml is well formated
+  # compile time check to ensure yaml is well formatted
   content = File.read file
   YAML.parse content
 
@@ -17,12 +17,11 @@ files = Dir.glob "#{dir}/*.yml" do |file|
   puts "I18nENDTOKEN"
 
   puts <<-EOF
-    if backend.translations[\"#{lang}\"]?
-      backend.translations[\"#{lang}\"].merge!(I18n::Backend::Yaml.normalize(lang_data))
+    if __backend__.translations["#{lang}"]?
+      __backend__.translations["#{lang}"].merge!(I18n::Backend::Yaml.normalize(lang_data))
     else
-      backend.translations[\"#{lang}\"] = I18n::Backend::Yaml.normalize(lang_data)
+      __backend__.available_locales << "#{lang}"
+      __backend__.translations["#{lang}"] = I18n::Backend::Yaml.normalize(lang_data)
     end
-
-    backend.available_locales << \"#{lang}\"
   EOF
 end


### PR DESCRIPTION
#### Changes

* replace travis with github actions. 

Taking into account recent issue with installing crystal on travis runners github actions is much more flexible and reliable option

* remove nested macro evaluation for `I18n::Backend::Yaml.embed` and add simple test
* fix unnecessary adding already existing locale in `src/i18n/backend/i18n_embed.cr`